### PR TITLE
Ignore ./input and ./output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ test-aqinda/output/
 test-europeana/output/
 mysql-data/
 
+# local directories mounted as Docker volumes by default
+./input
+./output
+
 # Compiled class file
 *.class
 


### PR DESCRIPTION
These are documented to be default volumes (currently it's test-aquinda but will be changed back for general usage).